### PR TITLE
Matrixクラスのインデックス計算をリファクタリング

### DIFF
--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -363,30 +363,33 @@ uint64_t Matrix<T>::convertTileToArray(const uint32_t &ti, const uint32_t &tj, c
     uint64_t index = {0};
     switch ( static_cast<unsigned short>(ordering_) ) {
         case static_cast<unsigned short>(Ordering::TileMatrixColumnMajorTileColumnMajor):
-            index += ((tj != (this->q_ - 1)) || (this->q_ == 1)) ? ti * (this->mb_) * (this->nb_) : ti * (this->nb_) * (this->n_ % this->nb_);
+            index += ((tj != (this->q_ - 1)) || ((this->n_) % (this->nb_) == 0)) ? ti * (this->mb_) * (this->nb_) : ti * (this->nb_) * ((this->n_) % (this->nb_));
             index += tj * (this->m_) * (this->nb_);
-            index += ((ti != (this->p_ - 1)) || (this->p_ == 1)) ? j * (this->mb_) : j * (this->m_ % this->mb_);
+            index += ((ti != (this->p_ - 1)) || ((this->m_) % (this->mb_) == 0)) ? j * (this->mb_) : j * ((this->m_) % (this->mb_));
             index += i;
             break;
         case static_cast<unsigned short>(Ordering::TileMatrixRowMajorTileColumnMajor):
-            index += ti * (this->mb_ * this->n_);
-            index += ((ti != (this->p_ - 1)) || (this->p_ == 1)) ? tj * (this->mb_ * this->nb_) : tj * (this->m_ % this->mb_) * this->nb_;
-            index += ((ti != (this->p_ - 1)) || (this->p_ == 1)) ? j * (this->mb_) : j * (this->m_ % this->mb_);
+            index += ti * (this->mb_) * (this->n_);
+            index += ((ti != (this->p_ - 1)) || ((this->m_) % (this->mb_) == 0)) ? tj * (this->mb_) * (this->nb_) : tj * ((this->m_) % (this->mb_)) * (this->nb_);
+            index += ((ti != (this->p_ - 1)) || ((this->m_) % (this->mb_) == 0)) ? j * (this->mb_) : j * ((this->m_) % (this->mb_));
             index += i;
             break;
         case static_cast<unsigned short>(Ordering::TileMatrixColumnMajorTileRowMajor):
-            index += ((tj != (this->q_ - 1)) || (this->q_ == 1)) ? ti * (this->mb_) * (this->nb_) : ti * (this->nb_) * (this->n_ % this->nb_);
+            index += ((tj != (this->q_ - 1)) || ((this->n_) % (this->nb_) == 0)) ? ti * (this->mb_) * (this->nb_) : ti * (this->nb_) * ((this->n_) % (this->nb_));
             index += tj * (this->m_) * (this->nb_);
-            index += ((tj != (this->q_ - 1)) || (this->q_ == 1)) ? i * (this->nb_) : i * (this->n_ % this->nb_);
+            index += ((tj != (this->q_ - 1)) || ((this->n_) % (this->nb_) == 0)) ? i * (this->nb_) : i * ((this->n_) % (this->nb_));
             index += j;
         case static_cast<unsigned short>(Ordering::TileMatrixRowMajorTileRowMajor):
-            index += ti * (this->mb_ * this->n_);
-            index += ((ti != (this->p_ - 1)) || (this->p_ == 1)) ? tj * (this->mb_ * this->nb_) : tj * (this->m_ % this->mb_) * this->nb_;
-            index += ((tj != (this->q_ - 1)) || (this->q_ == 1)) ? i * (this->nb_) : i * (this->n_ % this->nb_);
+            index += ti * (this->mb_) * (this->n_);
+            index += ((ti != (this->p_ - 1)) || ((this->m_) % (this->mb_) == 0)) ? tj * (this->mb_) * (this->nb_) : tj * ((this->m_) % (this->mb_)) * (this->nb_);
+            index += ((tj != (this->q_ - 1)) || ((this->n_) % (this->nb_) == 0)) ? i * (this->nb_) : i * ((this->n_) % (this->nb_));
             index += j;
         default:
             break;
     }
+
+    assert( index < (this->m_) * (this->n_));
+
     return index;
 }
 


### PR DESCRIPTION
Matrixクラスのインデックス計算が、さまざまなタイルマトリックスのストレージオーダーに対応するように更新されました。 この変更により、ユーザーはタイル化されたマトリックスとその内部タイルのストレージスキームを指定でき、行優先または列優先のパターンを適用できます。 さらに、タイル座標を配列インデックスに変換する方法も改善されました。
この簡素化と標準化により、この変換が必要となる場面全体でのプロセスが合理化されます。