### PR TITLE
行列のインデックス操作をリファクタリングし、出力関数を整理

### DIFF
--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -363,27 +363,29 @@ uint64_t Matrix<T>::convertTileToArray(const uint32_t &ti, const uint32_t &tj, c
     uint64_t index = {0};
     switch ( static_cast<unsigned short>(ordering_) ) {
         case static_cast<unsigned short>(Ordering::TileMatrixColumnMajorTileColumnMajor):
-            index += ((tj != (this->q_ - 1)) || ((this->n_) % (this->nb_) == 0)) ? ti * (this->mb_) * (this->nb_) : ti * (this->nb_) * ((this->n_) % (this->nb_));
+            index += ti * (this->mb_) * Matrix<T>::nb(ti, tj);
             index += tj * (this->m_) * (this->nb_);
-            index += ((ti != (this->p_ - 1)) || ((this->m_) % (this->mb_) == 0)) ? j * (this->mb_) : j * ((this->m_) % (this->mb_));
+            index += j * Matrix<T>::mb(ti, tj);
             index += i;
             break;
         case static_cast<unsigned short>(Ordering::TileMatrixRowMajorTileColumnMajor):
             index += ti * (this->mb_) * (this->n_);
-            index += ((ti != (this->p_ - 1)) || ((this->m_) % (this->mb_) == 0)) ? tj * (this->mb_) * (this->nb_) : tj * ((this->m_) % (this->mb_)) * (this->nb_);
-            index += ((ti != (this->p_ - 1)) || ((this->m_) % (this->mb_) == 0)) ? j * (this->mb_) : j * ((this->m_) % (this->mb_));
+            index += tj * Matrix<T>::mb(ti, tj) * (this->nb_);
+            index += j * Matrix<T>::mb(ti, tj);
             index += i;
             break;
         case static_cast<unsigned short>(Ordering::TileMatrixColumnMajorTileRowMajor):
-            index += ((tj != (this->q_ - 1)) || ((this->n_) % (this->nb_) == 0)) ? ti * (this->mb_) * (this->nb_) : ti * (this->nb_) * ((this->n_) % (this->nb_));
+            index += ti * (this->mb_) * Matrix<T>::nb(ti, tj);
             index += tj * (this->m_) * (this->nb_);
-            index += ((tj != (this->q_ - 1)) || ((this->n_) % (this->nb_) == 0)) ? i * (this->nb_) : i * ((this->n_) % (this->nb_));
+            index += i * Matrix<T>::nb(ti, tj);
             index += j;
+            break;
         case static_cast<unsigned short>(Ordering::TileMatrixRowMajorTileRowMajor):
             index += ti * (this->mb_) * (this->n_);
-            index += ((ti != (this->p_ - 1)) || ((this->m_) % (this->mb_) == 0)) ? tj * (this->mb_) * (this->nb_) : tj * ((this->m_) % (this->mb_)) * (this->nb_);
-            index += ((tj != (this->q_ - 1)) || ((this->n_) % (this->nb_) == 0)) ? i * (this->nb_) : i * ((this->n_) % (this->nb_));
+            index += tj * Matrix<T>::mb(ti, tj) * (this->nb_);
+            index += i * Matrix<T>::nb(ti, tj);
             index += j;
+            break;
         default:
             break;
     }

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -185,7 +185,7 @@ public:
      * @brief (ti,tj)がタイルの最後の場合には、行の端数を返し、それ以外の場合にはタイルの行数を返す。
      */
     uint32_t mb(const int ti, const int tj) const {
-        return (ti == (this->p_ - 1) ? (this->m_) % (this->mb_) : this->mb_);
+        return ( ( (this->m_) % (this->mb_) == 0) || (ti != ( (this->p_) - 1) ) ) ? (this->mb_) : (this->m_) % (this->mb_);
     }
     /**
      * @brief タイルの列数を取得するゲッター。
@@ -195,7 +195,7 @@ public:
      * @brief (ti,tj)がタイルの最後の場合には、列の端数を返し、それ以外の場合にはタイルの列数を返す。
      */
     uint32_t nb(const int ti, const int tj) const {
-        return (tj == (this->q_ - 1) ? (this->n_) % (this->nb_) : this->nb_);
+        return ( ( (this->n_) % (this->nb_) == 0) || (tj != ( (this->q_) - 1) ) ) ? (this->nb_) : (this->n_) % (this->nb_);
     }
     /**
      * @brief 行方向のタイル数を取得するゲッター。
@@ -287,13 +287,10 @@ public:
     friend std::ostream& operator<< (std::ostream &os, const Matrix<T> &ma){
         uint32_t m = ma.m();
         uint32_t n = ma.n();
-        uint32_t mb = ma.mb();
-        uint32_t nb = ma.nb();
 
-        for (uint32_t i = 0; i < m; i++) {
-            for (uint32_t j = 0; j < n; j++) {
-
-                os << ma( i, j) << " ";
+        for (uint32_t i = 0; i < m; ++i) {
+            for (uint32_t j = 0; j < n; ++j) {
+                os << ma(i, j) << " ";
             }
             os << std::endl;
         }


### PR DESCRIPTION
行列のインデックス操作の条件が関数の分解を用いて単純化され、出力関数のコードが明確さのために整理されました。 これらの変更により、コードがよりすっきりと読みやすくなり、タイルのサイズの正確な計算とそのインデックス計算での取り扱いが保証されます。 ループの増分も全体を通して標準化されました。