### PR TITLE
Add [[nodiscard]] attribute and update switch case type in matrix

### DIFF
--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -361,26 +361,26 @@ void Matrix<T>::zero() {
 template<typename T>
 uint64_t Matrix<T>::convertTileToArray(const uint32_t &ti, const uint32_t &tj, const uint32_t &i, const uint32_t &j) const{
     uint64_t index = {0};
-    switch ( static_cast<unsigned short>(ordering_) ) {
-        case static_cast<unsigned short>(Ordering::TileMatrixColumnMajorTileColumnMajor):
+    switch ( static_cast<std::underlying_type<Ordering>::type>(ordering_) ) {
+        case static_cast<std::underlying_type<Ordering>::type>(Ordering::TileMatrixColumnMajorTileColumnMajor):
             index += ti * (this->mb_) * Matrix<T>::nb(ti, tj);
             index += tj * (this->m_) * (this->nb_);
             index += j * Matrix<T>::mb(ti, tj);
             index += i;
             break;
-        case static_cast<unsigned short>(Ordering::TileMatrixRowMajorTileColumnMajor):
+        case static_cast<std::underlying_type<Ordering>::type>(Ordering::TileMatrixRowMajorTileColumnMajor):
             index += ti * (this->mb_) * (this->n_);
             index += tj * Matrix<T>::mb(ti, tj) * (this->nb_);
             index += j * Matrix<T>::mb(ti, tj);
             index += i;
             break;
-        case static_cast<unsigned short>(Ordering::TileMatrixColumnMajorTileRowMajor):
+        case static_cast<std::underlying_type<Ordering>::type>(Ordering::TileMatrixColumnMajorTileRowMajor):
             index += ti * (this->mb_) * Matrix<T>::nb(ti, tj);
             index += tj * (this->m_) * (this->nb_);
             index += i * Matrix<T>::nb(ti, tj);
             index += j;
             break;
-        case static_cast<unsigned short>(Ordering::TileMatrixRowMajorTileRowMajor):
+        case static_cast<std::underlying_type<Ordering>::type>(Ordering::TileMatrixRowMajorTileRowMajor):
             index += ti * (this->mb_) * (this->n_);
             index += tj * Matrix<T>::mb(ti, tj) * (this->nb_);
             index += i * Matrix<T>::nb(ti, tj);

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -172,39 +172,39 @@ public:
     /**
      * @brief 行数を取得するゲッター。
      */
-    uint32_t m() const { return this->m_; }
+    [[nodiscard]] uint32_t m() const { return this->m_; }
     /**
      * @brief 列数を取得するゲッター。
      */
-    uint32_t n() const { return this->n_; }
+    [[nodiscard]] uint32_t n() const { return this->n_; }
     /**
      * @brief タイルの行数を取得するゲッター。
      */
-    uint32_t mb() const { return this->mb_; }
+    [[nodiscard]] uint32_t mb() const { return this->mb_; }
     /**
      * @brief (ti,tj)がタイルの最後の場合には、行の端数を返し、それ以外の場合にはタイルの行数を返す。
      */
-    uint32_t mb(const int ti, const int tj) const {
+    [[nodiscard]] uint32_t mb(const int ti, const int tj) const {
         return ( ( (this->m_) % (this->mb_) == 0) || (ti != ( (this->p_) - 1) ) ) ? (this->mb_) : (this->m_) % (this->mb_);
     }
     /**
      * @brief タイルの列数を取得するゲッター。
      */
-    uint32_t nb() const { return this->nb_; }
+    [[nodiscard]] uint32_t nb() const { return this->nb_; }
     /**
      * @brief (ti,tj)がタイルの最後の場合には、列の端数を返し、それ以外の場合にはタイルの列数を返す。
      */
-    uint32_t nb(const int ti, const int tj) const {
+    [[nodiscard]] uint32_t nb(const int ti, const int tj) const {
         return ( ( (this->n_) % (this->nb_) == 0) || (tj != ( (this->q_) - 1) ) ) ? (this->nb_) : (this->n_) % (this->nb_);
     }
     /**
      * @brief 行方向のタイル数を取得するゲッター。
      */
-    uint32_t p() const { return this->p_; }
+    [[nodiscard]] uint32_t p() const { return this->p_; }
     /**
      * @brief 列方向のタイル数を取得するゲッター。
      */
-    uint32_t q() const { return this->q_; }
+    [[nodiscard]] uint32_t q() const { return this->q_; }
 
     /**
      * @brief 行列の要素にランダムな数値を代入するメソッド。
@@ -313,6 +313,6 @@ private:
  * @param j  タイル内の列インデックスです。
  * @return 計算された1次元配列のインデックスを返します。
  */
-    uint64_t convertTileToArray(const uint32_t &ti, const uint32_t &tj,
-                                const uint32_t &i, const uint32_t &j) const;
+    [[nodiscard]] uint64_t convertTileToArray(const uint32_t &ti, const uint32_t &tj,
+                                              const uint32_t &i, const uint32_t &j) const;
 };


### PR DESCRIPTION
Added [[nodiscard]] attribute to getter methods in matrix.hpp to suggest compiler that a method return value should not be ignored. The type of the switch case in the convertTileToArray method in matrix.cpp was updated from an unsigned short to std's underlying_type to better handle the enum class.