### PR TITLE
Repositioned certain assertions within the code and removed some

### DIFF
--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -26,8 +26,6 @@ Matrix<T>::~Matrix() {
  */
 template<typename T>
 uint32_t Matrix<T>::mb(const uint32_t &ti, const uint32_t &tj) const {
-    assert( 0 <= ti );
-    assert( 0 <= tj );
     assert( ti < this->p_);
     assert( tj < this->q_);
     return ( ( (this->m_) % (this->mb_) == 0) || (ti != ( (this->p_) - 1) ) ) ? (this->mb_) : (this->m_) % (this->mb_);
@@ -38,8 +36,6 @@ uint32_t Matrix<T>::mb(const uint32_t &ti, const uint32_t &tj) const {
  */
 template<typename T>
 uint32_t Matrix<T>::nb(const uint32_t &ti, const uint32_t &tj) const {
-    assert( 0 <= ti );
-    assert( 0 <= tj );
     assert( ti < this->p_);
     assert( tj < this->q_);
     return ( ( (this->n_) % (this->nb_) == 0) || (tj != ( (this->q_) - 1) ) ) ? (this->nb_) : (this->n_) % (this->nb_);
@@ -79,9 +75,7 @@ void Matrix<T>::gen_rnd_elm() {
  */
 template<typename T>
 T* Matrix<T>::elm(const uint32_t &ti, const uint32_t &tj) const {
-    assert(ti >= 0);
     assert(ti < (this->p_));
-    assert(tj >= 0);
     assert(tj < (this->q_));
 
     uint32_t pos = Matrix<T>::convertTileToArray(ti, tj, 0, 0);
@@ -109,14 +103,10 @@ T* Matrix<T>::elm(const uint32_t &ti, const uint32_t &tj) const {
 template<typename T>
 T* Matrix<T>::elm(const uint32_t &ti, const uint32_t &tj,
                   const uint32_t &i, const uint32_t &j) const {
-    assert(i >= 0);
     assert(i < (ti == (this->p_ - 1) ? (this->m_) % (this->mb_) : this->mb_));
-    assert(j >= 0);
     assert(j < (tj == (this->q_ - 1) ? (this->n_) % (this->nb_) : this->nb_));
 
-    assert(ti >= 0);
     assert(ti < this->p_);
-    assert(tj >= 0);
     assert(tj < this->q_);
 
     uint64_t pos = Matrix<T>::convertTileToArray( ti, tj, i, j);
@@ -321,7 +311,6 @@ bool Matrix<T>::operator==(const Matrix<T> &M) {
  */
 template<typename T>
 T &Matrix<T>::operator[](const uint64_t &i) const {
-    assert(i >= 0);
     assert(i < (this->m_)*(this->n_));
 
     return top_[i];
@@ -339,9 +328,7 @@ T &Matrix<T>::operator[](const uint64_t &i) const {
  */
 template<typename T>
 T &Matrix<T>::operator()(const uint32_t &i, const uint32_t &j) const {
-    assert(i >= 0);
     assert(i < (this->m_));
-    assert(j >= 0);
     assert(j < (this->n_));
 
     const uint32_t ti = i / this->mb_;
@@ -430,7 +417,8 @@ uint64_t Matrix<T>::convertTileToArray(const uint32_t &ti, const uint32_t &tj, c
  */
 template<typename T>
 void Matrix<T>::set_ts(uint32_t ts) {
-    assert( ts > 0);
+    assert( ts < m_ );
+    assert( ts < n_ );
 
     Matrix new_matrix( m_, n_, ts, ordering_);
 
@@ -451,8 +439,8 @@ void Matrix<T>::set_ts(uint32_t ts) {
    */
 template<typename T>
 void Matrix<T>::set_ts(uint32_t mb, uint32_t nb) {
-    assert( mb > 0);
-    assert( nb > 0);
+    assert( mb < m_);
+    assert( nb < n_);
 
     Matrix new_matrix( m_, n_, mb, nb, ordering_);
 

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -44,10 +44,6 @@ class Matrix {
 
 protected:
     /**
-     * @brief 行列の先頭への一意なポインタ。
-     */
-    std::unique_ptr<T[]> top_;     // pointer to the matrix
-    /**
      * @brief 行列の行数。
      */
     uint32_t m_;  // number of lows of the matrix or lda
@@ -71,6 +67,11 @@ protected:
      * @brief 列方向のタイル数。
      */
     uint32_t q_;  // number of column tiles
+
+    /**
+     * @brief 行列の先頭への一意なポインタ。
+     */
+    std::unique_ptr<T[]> top_;     // pointer to the matrix
 
     /**
      * @brief オーダリングオブジェクト


### PR DESCRIPTION
I've improved the efficiency and appropriateness of the code by repositioning certain assertions within the Matrix class. Moreover, I deleted the assertions for non-negative integers that physically can't exceed their range, saving time in code reading and debugging.