### PR TITLE
Add `achlioptas` method to initialize matrix elements with a sparse r…

### DIFF
--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -60,6 +60,17 @@ void Matrix<T>::bernoulli(uint32_t seed) {
 }
 
 template<typename T>
+void Matrix<T>::achlioptas(uint32_t seed) {
+    std::mt19937 gen(seed);
+    // 区間 [0, 5] の一様整数分布: 0–1 → +1, 2–3 → -1, 4–5 → 0
+    std::uniform_int_distribution<int> dist(0, 5);
+    for (uint64_t i = 0; i < static_cast<uint64_t>(m_) * n_; ++i) {
+        int r = dist(gen);
+        top_.get()[i] = (r == 0) ? T(1) : (r == 1) ? T(-1) : T(0);
+    }
+}
+
+template<typename T>
 void Matrix<T>::gauss(uint32_t seed) {
     std::mt19937 gen(seed);
     std::normal_distribution<T> dist(0.0, 1.0);

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -237,6 +237,16 @@ public:
      */
     void bernoulli(uint32_t seed = 20260107);
     /**
+     * @brief 行列の全要素を Achlioptas 分布で初期化するメソッド。
+     *
+     * 各要素は以下の確率で設定されます：
+     *   - 確率 1/6 : +1
+     *   - 確率 1/6 : -1
+     *   - 確率 2/3 :  0
+     * @param seed 乱数シード（デフォルト: 20260107）
+     */
+    void achlioptas(uint32_t seed = 20260107);
+    /**
      * @brief (ti,tj)要素へのポインタを返す。
      */
     T *elm(const uint32_t &ti, const uint32_t &tj) const;


### PR DESCRIPTION
…andom distribution

- Initializes elements with probabilities: 1/6 for +1, 1/6 for -1, and 2/3 for 0.
- Uses a uniform integer distribution for random sampling.